### PR TITLE
Try to cater for ArgoCD and patterns-operator namespace changes

### DIFF
--- a/templates/openshift/argo-role.yaml
+++ b/templates/openshift/argo-role.yaml
@@ -15,6 +15,12 @@ subjects:
   - kind: ServiceAccount
     name: openshift-gitops-argocd-application-controller
     namespace: openshift-gitops
+  - kind: ServiceAccount
+    name: vp-gitops-argocd-application-controller
+    namespace: vp-gitops
+  - kind: ServiceAccount
+    name: patterns-operator-controller-manager
+    namespace: patterns-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
Newer versions of the patterns operator (starting with 0.0.70)
will install the ArgoCD in the vp-gitops namespace.
Also the pattern operator itself (which needs access to check on the gitea route)
now runs by default in the patterns-operator namespace.
Add these two additional entities to the RBAC.

Tested and it fixes the issue.
